### PR TITLE
Fixed NVP++ to MVP++

### DIFF
--- a/src/player/modules/mvpPlusPlusEmotes.ts
+++ b/src/player/modules/mvpPlusPlusEmotes.ts
@@ -7,7 +7,7 @@ const settingItem = new Item(175);
 settingItem.displayName = '§fMVP++ Emotes';
 settingItem.lore = [
   '',
-  '§7Send NVP++ emotes',
+  '§7Send MVP++ emotes',
   '§7without having MVP++',
   '',
   `§7Current: §${config.modules.mvpppEmotes ? 'aEnabled' : 'cDisabled'}`,


### PR DESCRIPTION
There was a typo for MVP++ that will say NVP++ in /ss